### PR TITLE
Fix unknown command registry element

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -5,7 +5,7 @@ parchment     = "1.21.10:2025.10.12"
 fabric-api    = "0.140.0+1.21.11"
 fabric-kotlin = "1.13.5+kotlin.2.2.10"
 permissions   = "0.6.1"
-arcade        = "0.8.0-beta.6+1.21.11"
+arcade        = "0.8.1-beta.8+1.21.11"
 
 # Plugins
 fabric-loom   = "1.14-SNAPSHOT"


### PR DESCRIPTION
**The issue**
Using version 0.3.1+1.21.11 in single-player and running 
`/multiverse create from multiverse:void example:my_dimension random false` 
without an existing void dimension being present would throw the error: 
`commands.arguments.registry.element.unknown`

**The fix**
Updating the arcade version